### PR TITLE
Refactor User creation to not expect password confirmation

### DIFF
--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -28,7 +28,7 @@ class Api::V1::UsersController < ApplicationController
   private
 
   def user_params
-    params.require(:user).permit(:username, :email, :password, :password_confirmation)
+    params.require(:user).permit(:username, :email, :password)
   end
   def login_params
     params.require(:user).permit(:email, :password)

--- a/spec/requests/user_create_spec.rb
+++ b/spec/requests/user_create_spec.rb
@@ -9,14 +9,6 @@ RSpec.describe "User creation requests" do
       "password_confirmation": "password"
     }
   }
-  query_password_no_match = {
-    user: {
-      "username": "Hank Hill",
-      "email": "ProPAIaN@aol.com",
-      "password": "password",
-      "password_confirmation": "passwor"
-    }
-  }
   query_missing_username = {
     user: {
       "username": "",
@@ -62,15 +54,6 @@ RSpec.describe "User creation requests" do
       response = JSON.parse(@response.body)
 
       expect(response["email"]).to eq(["has already been taken"])
-    end
-  end
-
-  context "typo in password confirmation" do
-    it "returns error message" do
-      post '/api/v1/users', params: query_password_no_match
-      response = JSON.parse(@response.body)
-
-      expect(response["password_confirmation"]).to eq(["doesn't match Password"])
     end
   end
 


### PR DESCRIPTION
- [ X ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Styling- no new features

**Description:**
Refactor user creation to expect password without confirmation 

**What does this solve?:**
Removes unneeded code

**Notes:**
Front End will confirm password before it reaches the backend

- [ x ] All tests are passing
